### PR TITLE
Feature/preview profile side bar

### DIFF
--- a/frontend/src/components/FriendListSideBar/FriendListSideBar.tsx
+++ b/frontend/src/components/FriendListSideBar/FriendListSideBar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as S from "./styles";
 import ChonListItem from "./ChonListItem/ChonListItem";
 import { useAppSelector } from "store/hooks";
+import PreviewProfileSidebar from "containers/PreviewProfileSidebar/PreviewProfileSidebar";
 
 interface Props {}
 
@@ -19,6 +20,7 @@ const FriendListSideBar: React.FC<Props> = () => {
 
   return (
     <S.Container>
+      <PreviewProfileSidebar />
       <S.Header>친구 목록</S.Header>
       {friendList.length > 0 &&
         friendList.map(user => (

--- a/frontend/src/components/FriendListSideBar/styles.ts
+++ b/frontend/src/components/FriendListSideBar/styles.ts
@@ -5,6 +5,7 @@ export const Container = styled.div`
   min-width: 250px;
   max-width: 400px;
   background-color: ${themeBgColor};
+  position: relative;
 `;
 
 export const Header = styled.header`

--- a/frontend/src/components/Graph/Graph.tsx
+++ b/frontend/src/components/Graph/Graph.tsx
@@ -1,6 +1,6 @@
 import SearchBar from "components/SearchBar/SearchBar";
 import React, { useEffect, useRef } from "react";
-import { useAppSelector } from "store/hooks";
+import { useAppDispatch, useAppSelector } from "store/hooks";
 import useCanvas from "./hooks/useCanvas";
 
 import * as S from "./styles";

--- a/frontend/src/components/Graph/Graph.tsx
+++ b/frontend/src/components/Graph/Graph.tsx
@@ -6,16 +6,32 @@ import useCanvas from "./hooks/useCanvas";
 
 import * as S from "./styles";
 import { canvasActions } from "store/slices/canvas";
+import { getProfile, profileActions } from "store/slices/profile";
 
 interface Props {}
 
 const Graph: React.FC<Props> = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const divRef = useRef<HTMLDivElement>(null);
-  const canvas = useCanvas({ divRef: divRef, canvasRef: canvasRef });
+  const dispatch = useAppDispatch();
+  const onSetViewProfileCallback = (id: number | null) => {
+    if (id) {
+      dispatch(getProfile(id))
+        .unwrap()
+        .then(data => {
+          dispatch(profileActions.setPreviewProfile({ ...data, id }));
+        });
+    } else {
+      dispatch(profileActions.setPreviewProfile(null));
+    }
+  };
+  const canvas = useCanvas({
+    divRef: divRef,
+    canvasRef: canvasRef,
+    onSetViewProfileCallback,
+  });
   const users = useAppSelector(state => state.users);
   const search = useAppSelector(state => state.search);
-  const dispatch = useAppDispatch();
   const oneChonIdToExpandNetwork = useAppSelector(
     state => state.canvas.oneChonIdToExpandNetwork,
   );

--- a/frontend/src/components/Graph/Graph.tsx
+++ b/frontend/src/components/Graph/Graph.tsx
@@ -1,6 +1,6 @@
 import SearchBar from "components/SearchBar/SearchBar";
 import React, { useEffect, useRef } from "react";
-import { useAppDispatch, useAppSelector } from "store/hooks";
+import { useAppSelector } from "store/hooks";
 import useCanvas from "./hooks/useCanvas";
 
 import * as S from "./styles";

--- a/frontend/src/components/Graph/Graph.tsx
+++ b/frontend/src/components/Graph/Graph.tsx
@@ -1,9 +1,11 @@
 import SearchBar from "components/SearchBar/SearchBar";
 import React, { useEffect, useRef } from "react";
-import { useAppSelector } from "store/hooks";
+import { useAppDispatch, useAppSelector } from "store/hooks";
+import { BiLeftArrowAlt } from "react-icons/bi";
 import useCanvas from "./hooks/useCanvas";
 
 import * as S from "./styles";
+import { canvasActions } from "store/slices/canvas";
 
 interface Props {}
 
@@ -13,6 +15,10 @@ const Graph: React.FC<Props> = () => {
   const canvas = useCanvas({ divRef: divRef, canvasRef: canvasRef });
   const users = useAppSelector(state => state.users);
   const search = useAppSelector(state => state.search);
+  const dispatch = useAppDispatch();
+  const oneChonIdToExpandNetwork = useAppSelector(
+    state => state.canvas.oneChonIdToExpandNetwork,
+  );
   const currentUser = users.currentUser;
   const friendList = users.friendList;
   const isSearchMode = search.isSearchMode;
@@ -34,8 +40,30 @@ const Graph: React.FC<Props> = () => {
     }
   }, [currentUser, friendList, isSearchMode, filteredFriendList, canvas]);
 
+  useEffect(() => {
+    if (canvas && currentUser) {
+      if (oneChonIdToExpandNetwork) {
+        canvas.setCenterNode(oneChonIdToExpandNetwork);
+        canvas.setFriendNodes(oneChonIdToExpandNetwork);
+      } else {
+        canvas.setCenterNode(currentUser.id);
+        canvas.setFriendNodes(currentUser.id);
+      }
+    }
+  }, [canvas, oneChonIdToExpandNetwork, currentUser]);
+
   return (
     <S.CanvasContainer ref={divRef}>
+      {oneChonIdToExpandNetwork && (
+        <S.ResetCanvasButton
+          onClick={() => {
+            dispatch(canvasActions.setOneChonIdToExpandNetwork(null));
+          }}
+        >
+          <BiLeftArrowAlt size={22} />
+          나의 네트워크로 돌아가기
+        </S.ResetCanvasButton>
+      )}
       {isSearchMode && <SearchBar />}
       <canvas ref={canvasRef} />
     </S.CanvasContainer>

--- a/frontend/src/components/Graph/hooks/useCanvas.test.tsx
+++ b/frontend/src/components/Graph/hooks/useCanvas.test.tsx
@@ -7,11 +7,13 @@ import { renderHook } from "@testing-library/react-hooks";
 // reference: https://kooku0.github.io/blog/%EC%99%B8%EB%B6%80-%EB%9D%BC%EC%9D%B4%EB%B8%8C%EB%9F%AC%EB%A6%AC-%ED%85%8C%EC%8A%A4%ED%8A%B8%EC%BD%94%EB%93%9C-%EC%A7%9C%EA%B8%B0/
 
 describe("useCanvas hook", () => {
+  let onSetViewProfileCallback: (id: number | null) => void;
   beforeEach(() => {
     // const mockCanvasElement = document.createElement("canvas");
     // const fakeCanvas = new Canvas(mockCanvasElement);
     jest.clearAllMocks();
     // (useCanvas as jest.Mock).mockReturnValue({} as Canvas);
+    onSetViewProfileCallback = jest.fn();
   });
 
   afterEach(() => {});
@@ -29,6 +31,7 @@ describe("useCanvas hook", () => {
       return useCanvas({
         divRef: containerRef,
         canvasRef: canvasRef,
+        onSetViewProfileCallback,
       });
     });
     result.current?.setSize(500, 500);
@@ -54,6 +57,7 @@ describe("useCanvas hook", () => {
       return useCanvas({
         divRef: containerRef,
         canvasRef: canvasRef,
+        onSetViewProfileCallback,
       });
     });
     result.current?.setWidth(500);
@@ -74,6 +78,7 @@ describe("useCanvas hook", () => {
       return useCanvas({
         divRef: containerRef,
         canvasRef: canvasRef,
+        onSetViewProfileCallback,
       });
     });
     waitFor(() => expect(result.current).toBe(null));
@@ -93,6 +98,7 @@ describe("useCanvas hook", () => {
       return useCanvas({
         divRef: containerRef,
         canvasRef: canvasRef,
+        onSetViewProfileCallback,
       });
     });
     result.current?.setSize(500, 500);

--- a/frontend/src/components/Graph/hooks/useCanvas.ts
+++ b/frontend/src/components/Graph/hooks/useCanvas.ts
@@ -1,16 +1,14 @@
 import { RefObject, useEffect, useState } from "react";
-import { useAppDispatch } from "store/hooks";
-import { getProfile, profileActions } from "store/slices/profile";
 import Canvas from "../utils/Canvas";
 
 interface Params {
   divRef: RefObject<HTMLDivElement>;
   canvasRef: RefObject<HTMLCanvasElement>;
+  onSetViewProfileCallback: (id: number) => void;
 }
 
-function useCanvas({ divRef, canvasRef }: Params) {
+function useCanvas({ divRef, canvasRef, onSetViewProfileCallback }: Params) {
   const [canvas, setCanvas] = useState<Canvas | null>(null);
-  const dispatch = useAppDispatch();
 
   useEffect(() => {
     if (canvasRef.current) {
@@ -37,26 +35,14 @@ function useCanvas({ divRef, canvasRef }: Params) {
       }
     };
 
-    const mouseDownSetPreviewProfile = (id: number | null) => {
-      if (id) {
-        dispatch(getProfile(id))
-          .unwrap()
-          .then(data => {
-            dispatch(profileActions.setPreviewProfile({ ...data, id }));
-          });
-      } else {
-        dispatch(profileActions.setPreviewProfile(null));
-      }
-    };
-
     onResize();
     window.addEventListener("resize", onResize);
-    canvas?.addEventListener("setPreviewProfile", mouseDownSetPreviewProfile);
+    canvas?.addEventListener("setPreviewProfile", onSetViewProfileCallback);
     return () => {
       window.removeEventListener("resize", onResize);
       canvas?.removeEventListener(
         "setPreviewProfile",
-        mouseDownSetPreviewProfile,
+        onSetViewProfileCallback,
       );
     };
   }, [canvas, divRef]);

--- a/frontend/src/components/Graph/hooks/useCanvas.ts
+++ b/frontend/src/components/Graph/hooks/useCanvas.ts
@@ -1,4 +1,6 @@
 import { RefObject, useEffect, useState } from "react";
+import { useAppDispatch } from "store/hooks";
+import { getProfile, profileActions } from "store/slices/profile";
 import Canvas from "../utils/Canvas";
 
 interface Params {
@@ -8,6 +10,7 @@ interface Params {
 
 function useCanvas({ divRef, canvasRef }: Params) {
   const [canvas, setCanvas] = useState<Canvas | null>(null);
+  const dispatch = useAppDispatch();
 
   useEffect(() => {
     if (canvasRef.current) {
@@ -34,10 +37,27 @@ function useCanvas({ divRef, canvasRef }: Params) {
       }
     };
 
+    const mouseDownSetPreviewProfile = (id: number | null) => {
+      if (id) {
+        dispatch(getProfile(id))
+          .unwrap()
+          .then(data => {
+            dispatch(profileActions.setPreviewProfile(data));
+          });
+      } else {
+        dispatch(profileActions.setPreviewProfile(null));
+      }
+    };
+
     onResize();
     window.addEventListener("resize", onResize);
+    canvas?.addEventListener("setPreviewProfile", mouseDownSetPreviewProfile);
     return () => {
       window.removeEventListener("resize", onResize);
+      canvas?.removeEventListener(
+        "setPreviewProfile",
+        mouseDownSetPreviewProfile,
+      );
     };
   }, [canvas, divRef]);
 

--- a/frontend/src/components/Graph/hooks/useCanvas.ts
+++ b/frontend/src/components/Graph/hooks/useCanvas.ts
@@ -42,7 +42,7 @@ function useCanvas({ divRef, canvasRef }: Params) {
         dispatch(getProfile(id))
           .unwrap()
           .then(data => {
-            dispatch(profileActions.setPreviewProfile(data));
+            dispatch(profileActions.setPreviewProfile({ ...data, id }));
           });
       } else {
         dispatch(profileActions.setPreviewProfile(null));

--- a/frontend/src/components/Graph/styles.ts
+++ b/frontend/src/components/Graph/styles.ts
@@ -9,3 +9,16 @@ export const CanvasContainer = styled.div`
   flex: 1 0;
   overflow: hidden;
 `;
+
+export const ResetCanvasButton = styled.button`
+  display: flex;
+  background: none;
+  border: none;
+  align-items: center;
+  margin-top: 15px;
+  margin-left: 15px;
+  cursor: pointer;
+  position: absolute;
+  font-weight: bold;
+  font-size: 15px;
+`;

--- a/frontend/src/components/Graph/utils/Canvas.ts
+++ b/frontend/src/components/Graph/utils/Canvas.ts
@@ -17,7 +17,8 @@ import {
 import { addEvent, removeEvent, touchy, TouchyEvent } from "./touch";
 import { OneChonInfo } from "types/friend.types";
 import { ThemeColor } from "styles/common.styles";
-export default class Canvas {
+import EventDispatcher from "./eventDispatcher";
+export default class Canvas extends EventDispatcher {
   private MAX_SCALE = 2;
 
   private MIN_SCALE = 0.6;
@@ -78,6 +79,7 @@ export default class Canvas {
   isOneChonJourneyFinished = false;
 
   constructor(canvas: HTMLCanvasElement) {
+    super();
     this.element = canvas;
     this.ctx = canvas.getContext("2d")!;
 
@@ -133,6 +135,7 @@ export default class Canvas {
     if (touchedNode) {
       // TODO
       // Add node click action
+      this.emit("setPreviewProfile", touchedNode.id);
       if (
         this.oneChonNodes?.find(
           oneChonNode => oneChonNode.id === touchedNode.id,
@@ -141,6 +144,8 @@ export default class Canvas {
         this.setCenterNode(touchedNode.id);
         this.setFriendNodes(touchedNode.id);
       }
+    } else {
+      this.emit("setPreviewProfile", null);
     }
 
     if (window.TouchEvent && evt instanceof TouchEvent) {

--- a/frontend/src/components/Graph/utils/Canvas.ts
+++ b/frontend/src/components/Graph/utils/Canvas.ts
@@ -136,14 +136,14 @@ export default class Canvas extends EventDispatcher {
       // TODO
       // Add node click action
       this.emit("setPreviewProfile", touchedNode.id);
-      if (
-        this.oneChonNodes?.find(
-          oneChonNode => oneChonNode.id === touchedNode.id,
-        )
-      ) {
-        this.setCenterNode(touchedNode.id);
-        this.setFriendNodes(touchedNode.id);
-      }
+      // if (
+      //   this.oneChonNodes?.find(
+      //     oneChonNode => oneChonNode.id === touchedNode.id,
+      //   )
+      // ) {
+      //   this.setCenterNode(touchedNode.id);
+      //   this.setFriendNodes(touchedNode.id);
+      // }
     } else {
       this.emit("setPreviewProfile", null);
     }

--- a/frontend/src/components/Graph/utils/Canvas.ts
+++ b/frontend/src/components/Graph/utils/Canvas.ts
@@ -133,17 +133,7 @@ export default class Canvas extends EventDispatcher {
     this.panPoint.lastMousePos = { x: point.offsetX, y: point.offsetY };
     const touchedNode = this.nodes.find(node => node.isTouched(pointCoord));
     if (touchedNode) {
-      // TODO
-      // Add node click action
       this.emit("setPreviewProfile", touchedNode.id);
-      // if (
-      //   this.oneChonNodes?.find(
-      //     oneChonNode => oneChonNode.id === touchedNode.id,
-      //   )
-      // ) {
-      //   this.setCenterNode(touchedNode.id);
-      //   this.setFriendNodes(touchedNode.id);
-      // }
     } else {
       this.emit("setPreviewProfile", null);
     }

--- a/frontend/src/components/Graph/utils/eventDispatcher.ts
+++ b/frontend/src/components/Graph/utils/eventDispatcher.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/ban-types */
+class Event {
+  private name: string;
+
+  callbacks: Array<Function>;
+
+  constructor(name: string) {
+    this.name = name;
+    this.callbacks = [];
+  }
+
+  on(cb: Function) {
+    this.callbacks.push(cb);
+  }
+
+  off(cb: Function) {
+    const idx = this.callbacks.findIndex(callback => callback === cb);
+    this.callbacks.splice(idx, 1);
+  }
+
+  toString() {
+    return this.name;
+  }
+}
+
+export default class EventDispatcher {
+  events: { [name: string]: Event };
+
+  constructor() {
+    this.events = {};
+  }
+
+  emit(name: string, ...args: Array<unknown>) {
+    if (!this.events[name]) {
+      return;
+    }
+
+    this.events[name].callbacks.forEach(cb => {
+      cb(...args);
+    });
+  }
+
+  addEventListener(name: string, cb: Function): void {
+    if (!this.events[name]) {
+      this.events[name] = new Event(name);
+    }
+
+    this.events[name].on(cb);
+  }
+
+  removeEventListener(name: string, cb?: Function) {
+    if (!cb) {
+      delete this.events[name];
+      return;
+    }
+
+    this.events[name].off(cb);
+  }
+}

--- a/frontend/src/containers/PreviewProfileSidebar/PreviewProfileSidebar.tsx
+++ b/frontend/src/containers/PreviewProfileSidebar/PreviewProfileSidebar.tsx
@@ -8,6 +8,7 @@ import {
 import { Profile } from "server/models/profile.model";
 import { QualityTags } from "server/models/qualityTags.model";
 import { useAppDispatch, useAppSelector } from "store/hooks";
+import { canvasActions } from "store/slices/canvas";
 import {
   getFriendRequestBetweenUsers,
   postFriendRequest,
@@ -24,6 +25,10 @@ const PreviewProfileSidebar: React.FC = () => {
   const currentUser = useAppSelector(state => state.users.currentUser);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+  const oneChonIdToExpandNetwork = useAppSelector(
+    state => state.canvas.oneChonIdToExpandNetwork,
+  );
+
   const [existingFriendRequest, setExistingFriendRequest] =
     useState<FriendRequest | null>(null);
   const alert = useAlert();
@@ -110,6 +115,9 @@ const PreviewProfileSidebar: React.FC = () => {
     }
   };
 
+  const expandNetworkOnUser = (userId: number | null) => {
+    dispatch(canvasActions.setOneChonIdToExpandNetwork(userId));
+  };
   return (
     <S.Container isOpen={previewProfile !== null}>
       <S.Header>
@@ -146,8 +154,21 @@ const PreviewProfileSidebar: React.FC = () => {
 
         {friendList.findIndex(element => element.id === profile?.id) !== -1 && (
           <>
-            <S.ActionButton disabled={false}>
-              친구 네트워크 확인하기
+            <S.ActionButton
+              disabled={false}
+              onClick={() => {
+                if (profile) {
+                  if (!oneChonIdToExpandNetwork) {
+                    expandNetworkOnUser(profile.id);
+                  } else {
+                    expandNetworkOnUser(null);
+                  }
+                }
+              }}
+            >
+              {oneChonIdToExpandNetwork
+                ? "나의 네트워크로 돌아가기 "
+                : "친구 네트워크 확장하기"}
             </S.ActionButton>
             <S.ActionButton
               disabled={false}

--- a/frontend/src/containers/PreviewProfileSidebar/PreviewProfileSidebar.tsx
+++ b/frontend/src/containers/PreviewProfileSidebar/PreviewProfileSidebar.tsx
@@ -1,12 +1,52 @@
 import React from "react";
 import { useAppSelector } from "store/hooks";
+import { ThemeColor } from "styles/common.styles";
 import * as S from "./styles";
 
 const PreviewProfileSidebar: React.FC = () => {
   const previewProfile = useAppSelector(state => state.profile.previewProfile);
+  const friendList = useAppSelector(state => state.users.friendList);
+  const currentUser = useAppSelector(state => state.users.currentUser);
+  console.log(currentUser?.id, previewProfile?.id);
   return (
     <S.Container isOpen={previewProfile !== null}>
-      PreviewProfileSidebar
+      <S.Header>
+        <S.ProfileImageContainer>
+          <S.ProfileImage imgUrl={previewProfile?.imgUrl} />
+        </S.ProfileImageContainer>
+        <S.SkillTagsContainer>
+          <S.SkillTagTitle>태그들: </S.SkillTagTitle>
+          {previewProfile?.skillTags.map(skillTag => (
+            <S.SkillTag key={skillTag.name}>{skillTag.name}</S.SkillTag>
+          ))}
+        </S.SkillTagsContainer>
+      </S.Header>
+      <S.IntroductionContainer>
+        <S.Title>소개</S.Title>
+        <S.Introduction>{previewProfile?.introduction}</S.Introduction>
+      </S.IntroductionContainer>
+      <S.ActionButtonsContainer>
+        <S.ActionButton backgroundColor={ThemeColor}>
+          프로필 보기
+        </S.ActionButton>
+
+        {friendList.findIndex(element => element.id === previewProfile?.id) !==
+          -1 && (
+          <>
+            <S.ActionButton>친구 네트워크 확인하기</S.ActionButton>
+            <S.ActionButton>친구 끊기</S.ActionButton>
+          </>
+        )}
+        {previewProfile &&
+          currentUser &&
+          friendList.findIndex(element => element.id === previewProfile.id) ===
+            -1 &&
+          previewProfile.id !== currentUser.id && (
+            <>
+              <S.ActionButton>친구 추가하기</S.ActionButton>
+            </>
+          )}
+      </S.ActionButtonsContainer>
     </S.Container>
   );
 };

--- a/frontend/src/containers/PreviewProfileSidebar/PreviewProfileSidebar.tsx
+++ b/frontend/src/containers/PreviewProfileSidebar/PreviewProfileSidebar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useAppSelector } from "store/hooks";
 import { ThemeColor } from "styles/common.styles";
 import * as S from "./styles";
@@ -7,19 +7,43 @@ const PreviewProfileSidebar: React.FC = () => {
   const previewProfile = useAppSelector(state => state.profile.previewProfile);
   const friendList = useAppSelector(state => state.users.friendList);
   const currentUser = useAppSelector(state => state.users.currentUser);
-  console.log(currentUser?.id, previewProfile?.id);
+  const findUserName = (id: number | undefined) => {
+    if (!id) {
+      return "";
+    }
+    if (currentUser && id === currentUser.id) {
+      return currentUser.firstname + currentUser.lastname;
+    }
+    const oneChon = friendList.find(friend => friend.id === id);
+    if (oneChon) {
+      return oneChon.lastname + oneChon.firstname;
+    }
+    let twoChonName = "";
+    friendList.forEach(friend => {
+      return friend.chons.forEach(twoChon => {
+        if (twoChon.id === id) {
+          console.log(twoChon.lastname + twoChon.firstname);
+          twoChonName = twoChon.lastname + twoChon.firstname;
+        }
+      });
+    });
+    return twoChonName;
+  };
   return (
     <S.Container isOpen={previewProfile !== null}>
       <S.Header>
         <S.ProfileImageContainer>
           <S.ProfileImage imgUrl={previewProfile?.imgUrl} />
         </S.ProfileImageContainer>
-        <S.SkillTagsContainer>
-          <S.SkillTagTitle>태그들: </S.SkillTagTitle>
-          {previewProfile?.skillTags.map(skillTag => (
-            <S.SkillTag key={skillTag.name}>{skillTag.name}</S.SkillTag>
-          ))}
-        </S.SkillTagsContainer>
+        <S.ProfileBasicInfo>
+          <S.ProfileName>{findUserName(previewProfile?.id)}</S.ProfileName>
+          <S.SkillTagsContainer>
+            <S.SkillTagTitle>태그들: </S.SkillTagTitle>
+            {previewProfile?.skillTags.map(skillTag => (
+              <S.SkillTag key={skillTag.name}>{skillTag.name}</S.SkillTag>
+            ))}
+          </S.SkillTagsContainer>
+        </S.ProfileBasicInfo>
       </S.Header>
       <S.IntroductionContainer>
         <S.Title>소개</S.Title>

--- a/frontend/src/containers/PreviewProfileSidebar/PreviewProfileSidebar.tsx
+++ b/frontend/src/containers/PreviewProfileSidebar/PreviewProfileSidebar.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { useAppSelector } from "store/hooks";
+import * as S from "./styles";
+
+const PreviewProfileSidebar: React.FC = () => {
+  const previewProfile = useAppSelector(state => state.profile.previewProfile);
+  return (
+    <S.Container isOpen={previewProfile !== null}>
+      PreviewProfileSidebar
+    </S.Container>
+  );
+};
+
+export default PreviewProfileSidebar;

--- a/frontend/src/containers/PreviewProfileSidebar/PreviewProfileSidebar.tsx
+++ b/frontend/src/containers/PreviewProfileSidebar/PreviewProfileSidebar.tsx
@@ -1,4 +1,6 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import { Profile } from "server/models/profile.model";
+import { QualityTags } from "server/models/qualityTags.model";
 import { useAppSelector } from "store/hooks";
 import { ThemeColor } from "styles/common.styles";
 import * as S from "./styles";
@@ -7,6 +9,15 @@ const PreviewProfileSidebar: React.FC = () => {
   const previewProfile = useAppSelector(state => state.profile.previewProfile);
   const friendList = useAppSelector(state => state.users.friendList);
   const currentUser = useAppSelector(state => state.users.currentUser);
+  const [profile, setProfile] = useState<
+    (Profile & { qualityTags: QualityTags | null; id: number }) | null
+  >(null);
+  useEffect(() => {
+    if (previewProfile) {
+      setProfile(previewProfile);
+    }
+  }, [previewProfile]);
+
   const findUserName = (id: number | undefined) => {
     if (!id) {
       return "";
@@ -22,7 +33,6 @@ const PreviewProfileSidebar: React.FC = () => {
     friendList.forEach(friend => {
       return friend.chons.forEach(twoChon => {
         if (twoChon.id === id) {
-          console.log(twoChon.lastname + twoChon.firstname);
           twoChonName = twoChon.lastname + twoChon.firstname;
         }
       });
@@ -33,13 +43,13 @@ const PreviewProfileSidebar: React.FC = () => {
     <S.Container isOpen={previewProfile !== null}>
       <S.Header>
         <S.ProfileImageContainer>
-          <S.ProfileImage imgUrl={previewProfile?.imgUrl} />
+          <S.ProfileImage imgUrl={profile?.imgUrl} />
         </S.ProfileImageContainer>
         <S.ProfileBasicInfo>
-          <S.ProfileName>{findUserName(previewProfile?.id)}</S.ProfileName>
+          <S.ProfileName>{findUserName(profile?.id)}</S.ProfileName>
           <S.SkillTagsContainer>
             <S.SkillTagTitle>태그들: </S.SkillTagTitle>
-            {previewProfile?.skillTags.map(skillTag => (
+            {profile?.skillTags.map(skillTag => (
               <S.SkillTag key={skillTag.name}>{skillTag.name}</S.SkillTag>
             ))}
           </S.SkillTagsContainer>
@@ -47,25 +57,23 @@ const PreviewProfileSidebar: React.FC = () => {
       </S.Header>
       <S.IntroductionContainer>
         <S.Title>소개</S.Title>
-        <S.Introduction>{previewProfile?.introduction}</S.Introduction>
+        <S.Introduction>{profile?.introduction}</S.Introduction>
       </S.IntroductionContainer>
       <S.ActionButtonsContainer>
         <S.ActionButton backgroundColor={ThemeColor}>
           프로필 보기
         </S.ActionButton>
 
-        {friendList.findIndex(element => element.id === previewProfile?.id) !==
-          -1 && (
+        {friendList.findIndex(element => element.id === profile?.id) !== -1 && (
           <>
             <S.ActionButton>친구 네트워크 확인하기</S.ActionButton>
             <S.ActionButton>친구 끊기</S.ActionButton>
           </>
         )}
-        {previewProfile &&
+        {profile &&
           currentUser &&
-          friendList.findIndex(element => element.id === previewProfile.id) ===
-            -1 &&
-          previewProfile.id !== currentUser.id && (
+          friendList.findIndex(element => element.id === profile.id) === -1 &&
+          profile.id !== currentUser.id && (
             <>
               <S.ActionButton>친구 추가하기</S.ActionButton>
             </>

--- a/frontend/src/containers/PreviewProfileSidebar/PreviewProfileSidebar.tsx
+++ b/frontend/src/containers/PreviewProfileSidebar/PreviewProfileSidebar.tsx
@@ -1,7 +1,9 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Profile } from "server/models/profile.model";
 import { QualityTags } from "server/models/qualityTags.model";
-import { useAppSelector } from "store/hooks";
+import { useAppDispatch, useAppSelector } from "store/hooks";
+import { profileActions } from "store/slices/profile";
 import { ThemeColor } from "styles/common.styles";
 import * as S from "./styles";
 
@@ -9,6 +11,8 @@ const PreviewProfileSidebar: React.FC = () => {
   const previewProfile = useAppSelector(state => state.profile.previewProfile);
   const friendList = useAppSelector(state => state.users.friendList);
   const currentUser = useAppSelector(state => state.users.currentUser);
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
   const [profile, setProfile] = useState<
     (Profile & { qualityTags: QualityTags | null; id: number }) | null
   >(null);
@@ -39,6 +43,10 @@ const PreviewProfileSidebar: React.FC = () => {
     });
     return twoChonName;
   };
+
+  const goToProfile = (id: number) => {
+    navigate("/profile/" + id);
+  };
   return (
     <S.Container isOpen={previewProfile !== null}>
       <S.Header>
@@ -60,7 +68,15 @@ const PreviewProfileSidebar: React.FC = () => {
         <S.Introduction>{profile?.introduction}</S.Introduction>
       </S.IntroductionContainer>
       <S.ActionButtonsContainer>
-        <S.ActionButton backgroundColor={ThemeColor}>
+        <S.ActionButton
+          backgroundColor={ThemeColor}
+          onClick={() => {
+            if (profile) {
+              goToProfile(profile.id);
+              dispatch(profileActions.setPreviewProfile(null));
+            }
+          }}
+        >
           프로필 보기
         </S.ActionButton>
 

--- a/frontend/src/containers/PreviewProfileSidebar/styles.ts
+++ b/frontend/src/containers/PreviewProfileSidebar/styles.ts
@@ -1,21 +1,23 @@
-import { themeBgColor } from "components/FriendListSideBar/common.styles";
 import styled, { css, keyframes } from "styled-components";
 
 export const appearFromRight = keyframes`
   0% {
-
+    opacity: 0;
     transform: translateX(-100%);
   }
   100% {
+    opacity: 1;
     transform: translateX(0);
   }
 `;
 
 export const disappearToLeft = keyframes`
   0% {
+    opacity:1 ;
     transform: translateX(0);
   }
   100% {
+    opacity: 0;
     transform: translateX(-100%);
   }
 `;
@@ -31,6 +33,80 @@ export const Container = styled.div<{ isOpen: boolean }>`
   position: absolute;
   width: 100%;
   height: 100%;
-  background-color: ${"white"};
+  background-color: #d9d9d9;
   ${props => AppearFromSideSettings(props.isOpen)}
+`;
+
+export const Header = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 20px 10px;
+  margin-bottom: 20px;
+`;
+
+export const ProfileImageContainer = styled.div``;
+
+export const ProfileImage = styled.div<{ imgUrl: string | undefined }>`
+  background-image: ${props =>
+    props.imgUrl ? `url(${props.imgUrl})` : undefined};
+  width: 120px;
+  height: 120px;
+  background-size: cover;
+  border-radius: 50%;
+  border: 4px solid #000000;
+`;
+
+export const ProfileName = styled.div``;
+
+export const SkillTagTitle = styled.span``;
+
+export const SkillTagsContainer = styled.div`
+  display: flex;
+  margin-left: 10px;
+  flex-wrap: wrap;
+`;
+
+export const SkillTag = styled.div`
+  background-color: #d9d9d9;
+  white-space: nowrap;
+  display: inline-block;
+  margin-right: 5px;
+  padding: 5px 10px;
+  margin-bottom: 10px;
+  border-radius: 15px;
+  mask-image: linear-gradient(90deg, #000, 100%, transparent);
+  -webkit-mask-image: linear-gradient(90deg, #000, 100%, transparent);
+`;
+
+export const IntroductionContainer = styled.div`
+  padding: 0 10px;
+`;
+
+export const Introduction = styled.div``;
+
+export const Title = styled.div`
+  font-weight: bold;
+  font-size: 16px;
+  margin-bottom: 10px;
+`;
+
+export const ActionButtonsContainer = styled.div`
+  position: absolute;
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  flex-direction: column;
+  bottom: 70px;
+`;
+
+export const ActionButton = styled.button<{ backgroundColor?: string }>`
+  margin: 10px 30px;
+  border-radius: 10px;
+  padding: 8px 0;
+  color: black;
+  border: none;
+  font-weight: bold;
+  background: none;
+  cursor: pointer;
+  background-color: ${props => props.backgroundColor || "white"};
 `;

--- a/frontend/src/containers/PreviewProfileSidebar/styles.ts
+++ b/frontend/src/containers/PreviewProfileSidebar/styles.ts
@@ -107,10 +107,14 @@ export const ActionButtonsContainer = styled.div`
   bottom: 70px;
 `;
 
-export const ActionButton = styled.button<{ backgroundColor?: string }>`
+export const ActionButton = styled.button<{
+  backgroundColor?: string;
+  disabled: boolean;
+}>`
   margin: 10px 30px;
   border-radius: 10px;
   padding: 8px 0;
+  opacity: ${props => (props.disabled ? 0.5 : 1)};
   color: black;
   border: none;
   font-weight: bold;

--- a/frontend/src/containers/PreviewProfileSidebar/styles.ts
+++ b/frontend/src/containers/PreviewProfileSidebar/styles.ts
@@ -1,0 +1,9 @@
+import { themeBgColor } from "components/FriendListSideBar/common.styles";
+import styled from "styled-components";
+
+export const Container = styled.div<{ isOpen: boolean }>`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  margin-left: ${({ isOpen }) => (isOpen ? "0" : "-100%")};
+`;

--- a/frontend/src/containers/PreviewProfileSidebar/styles.ts
+++ b/frontend/src/containers/PreviewProfileSidebar/styles.ts
@@ -1,9 +1,36 @@
 import { themeBgColor } from "components/FriendListSideBar/common.styles";
-import styled from "styled-components";
+import styled, { css, keyframes } from "styled-components";
+
+export const appearFromRight = keyframes`
+  0% {
+
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(0);
+  }
+`;
+
+export const disappearToLeft = keyframes`
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+`;
+
+export const AppearFromSideSettings = (isVisible: boolean) => css`
+  transition: visibility 0.5s linear;
+  visibility: ${isVisible ? "visible" : "hidden"};
+  /* z-index: 15; */
+  animation: ${isVisible ? appearFromRight : disappearToLeft} 0.5s ease-out;
+`;
 
 export const Container = styled.div<{ isOpen: boolean }>`
   position: absolute;
   width: 100%;
   height: 100%;
-  margin-left: ${({ isOpen }) => (isOpen ? "0" : "-100%")};
+  background-color: ${"white"};
+  ${props => AppearFromSideSettings(props.isOpen)}
 `;

--- a/frontend/src/containers/PreviewProfileSidebar/styles.ts
+++ b/frontend/src/containers/PreviewProfileSidebar/styles.ts
@@ -44,6 +44,11 @@ export const Header = styled.div`
   margin-bottom: 20px;
 `;
 
+export const ProfileBasicInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 10px;
+`;
 export const ProfileImageContainer = styled.div``;
 
 export const ProfileImage = styled.div<{ imgUrl: string | undefined }>`
@@ -56,13 +61,16 @@ export const ProfileImage = styled.div<{ imgUrl: string | undefined }>`
   border: 4px solid #000000;
 `;
 
-export const ProfileName = styled.div``;
+export const ProfileName = styled.div`
+  font-weight: bold;
+  margin-bottom: 10px;
+`;
 
 export const SkillTagTitle = styled.span``;
 
 export const SkillTagsContainer = styled.div`
   display: flex;
-  margin-left: 10px;
+
   flex-wrap: wrap;
 `;
 

--- a/frontend/src/containers/PreviewProfileSidebar/styles.ts
+++ b/frontend/src/containers/PreviewProfileSidebar/styles.ts
@@ -121,4 +121,7 @@ export const ActionButton = styled.button<{
   background: none;
   cursor: pointer;
   background-color: ${props => props.backgroundColor || "white"};
+  :hover {
+    opacity: ${props => (!props.disabled ? 0.6 : 1)};
+  }
 `;

--- a/frontend/src/containers/PreviewProfileSidebar/styles.ts
+++ b/frontend/src/containers/PreviewProfileSidebar/styles.ts
@@ -2,22 +2,22 @@ import styled, { css, keyframes } from "styled-components";
 
 export const appearFromRight = keyframes`
   0% {
-    opacity: 0;
+    /* opacity: 0; */
     transform: translateX(-100%);
   }
   100% {
-    opacity: 1;
+    /* opacity: 1; */
     transform: translateX(0);
   }
 `;
 
 export const disappearToLeft = keyframes`
   0% {
-    opacity:1 ;
+    /* opacity:1 ; */
     transform: translateX(0);
   }
   100% {
-    opacity: 0;
+    /* opacity: 0; */
     transform: translateX(-100%);
   }
 `;
@@ -33,7 +33,7 @@ export const Container = styled.div<{ isOpen: boolean }>`
   position: absolute;
   width: 100%;
   height: 100%;
-  background-color: #d9d9d9;
+  background-color: #f2f2f2;
   ${props => AppearFromSideSettings(props.isOpen)}
 `;
 

--- a/frontend/src/containers/ProfilePage/ProfilePage.test.tsx
+++ b/frontend/src/containers/ProfilePage/ProfilePage.test.tsx
@@ -58,6 +58,7 @@ const renderProfilePage = (
         },
         profile: {
           currentProfile,
+          previewProfile: null,
         },
         friendRequests: {
           friendRequestToken: null,

--- a/frontend/src/containers/ProfilePage/ProfilePage.test.tsx
+++ b/frontend/src/containers/ProfilePage/ProfilePage.test.tsx
@@ -59,6 +59,7 @@ const renderProfilePage = (
         profile: {
           currentProfile,
           previewProfile: null,
+          previewProfileId: null,
         },
         friendRequests: {
           friendRequestToken: null,

--- a/frontend/src/containers/ProfilePage/ProfilePage.test.tsx
+++ b/frontend/src/containers/ProfilePage/ProfilePage.test.tsx
@@ -59,7 +59,6 @@ const renderProfilePage = (
         profile: {
           currentProfile,
           previewProfile: null,
-          previewProfileId: null,
         },
         friendRequests: {
           friendRequestToken: null,

--- a/frontend/src/store/slices/canvas.ts
+++ b/frontend/src/store/slices/canvas.ts
@@ -1,0 +1,25 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+export type CanvasState = {
+  oneChonIdToExpandNetwork: number | null;
+};
+
+const initialState: CanvasState = {
+  oneChonIdToExpandNetwork: null,
+};
+
+export const canvasSlice = createSlice({
+  name: "canvas",
+  initialState,
+  reducers: {
+    setOneChonIdToExpandNetwork: (
+      state,
+      action: PayloadAction<number | null>,
+    ) => {
+      state.oneChonIdToExpandNetwork = action.payload;
+    },
+  },
+});
+
+export const canvasActions = canvasSlice.actions;
+export default canvasSlice.reducer;

--- a/frontend/src/store/slices/friendRequests.ts
+++ b/frontend/src/store/slices/friendRequests.ts
@@ -26,15 +26,29 @@ const initialState: FriendRequestState = {
 /**
  * This gets all the new friend requests for the current user
  */
-export const getFriendRequests = createAsyncThunk<GetFriendRequestsResDto>(
-  "friendRequests/getFriendRequests",
-  async () => {
-    const response = await axios.get<GetFriendRequestsResDto>(
-      "/api/friendRequest/",
-    );
-    return response.data;
-  },
-);
+export const getFriendRequests = createAsyncThunk<
+  GetFriendRequestsResDto,
+  { user1Id: number; user2Id: number } | undefined
+>("friendRequests/getFriendRequests", async query => {
+  const response = await axios.get<GetFriendRequestsResDto>(
+    "/api/friendRequest/",
+    query ? { params: query } : undefined,
+  );
+  return response.data;
+});
+
+/**
+ * This gets a specific friendRequest between two users
+ */
+export const getFriendRequestBetweenUsers = createAsyncThunk<
+  FriendRequest,
+  { user1Id: number; user2Id: number }
+>("friendRequests/getFriendRequestBetweenUsers", async query => {
+  const response = await axios.get<FriendRequest>("/api/friendRequest/", {
+    params: query,
+  });
+  return response.data;
+});
 
 /**
  * This is for Creating a friend request

--- a/frontend/src/store/slices/index.ts
+++ b/frontend/src/store/slices/index.ts
@@ -8,12 +8,14 @@ import { RootState } from "..";
 import friendRequestSlice from "./friendRequests";
 import profileSlice from "./profile";
 import searchSlice from "./search";
+import canvasSlice from "./canvas";
 
 const rootReducer = combineReducers({
   users: userSlice,
   friendRequests: friendRequestSlice,
   profile: profileSlice,
   search: searchSlice,
+  canvas: canvasSlice,
 });
 
 export const setupStore = (preloadedState?: PreloadedState<RootState>) => {

--- a/frontend/src/store/slices/profile.ts
+++ b/frontend/src/store/slices/profile.ts
@@ -15,12 +15,16 @@ import { QualityTags } from "server/models/qualityTags.model";
 
 export type ProfileState = {
   currentProfile: (Profile & { qualityTags: QualityTags | null }) | null;
-  previewProfile: (Profile & { qualityTags: QualityTags | null }) | null;
+  previewProfile:
+    | (Profile & { qualityTags: QualityTags | null; id: number })
+    | null;
+  previewProfileId: number | null;
 };
 
 const initialState: ProfileState = {
   currentProfile: null,
   previewProfile: null,
+  previewProfileId: null,
 };
 
 export const postCreateProfile = createAsyncThunk<
@@ -68,6 +72,9 @@ export const profileSlice = createSlice({
   reducers: {
     setPreviewProfile: (state, action) => {
       state.previewProfile = action.payload;
+    },
+    setPreviewProfileId: (state, action) => {
+      state.previewProfileId = action.payload;
     },
   },
   extraReducers: builder => {

--- a/frontend/src/store/slices/profile.ts
+++ b/frontend/src/store/slices/profile.ts
@@ -18,13 +18,11 @@ export type ProfileState = {
   previewProfile:
     | (Profile & { qualityTags: QualityTags | null; id: number })
     | null;
-  previewProfileId: number | null;
 };
 
 const initialState: ProfileState = {
   currentProfile: null,
   previewProfile: null,
-  previewProfileId: null,
 };
 
 export const postCreateProfile = createAsyncThunk<
@@ -72,9 +70,6 @@ export const profileSlice = createSlice({
   reducers: {
     setPreviewProfile: (state, action) => {
       state.previewProfile = action.payload;
-    },
-    setPreviewProfileId: (state, action) => {
-      state.previewProfileId = action.payload;
     },
   },
   extraReducers: builder => {

--- a/frontend/src/store/slices/profile.ts
+++ b/frontend/src/store/slices/profile.ts
@@ -15,10 +15,12 @@ import { QualityTags } from "server/models/qualityTags.model";
 
 export type ProfileState = {
   currentProfile: (Profile & { qualityTags: QualityTags | null }) | null;
+  previewProfile: (Profile & { qualityTags: QualityTags | null }) | null;
 };
 
 const initialState: ProfileState = {
   currentProfile: null,
+  previewProfile: null,
 };
 
 export const postCreateProfile = createAsyncThunk<
@@ -63,7 +65,11 @@ export const editMyProfile = createAsyncThunk<
 export const profileSlice = createSlice({
   name: "profile",
   initialState: initialState,
-  reducers: {},
+  reducers: {
+    setPreviewProfile: (state, action) => {
+      state.previewProfile = action.payload;
+    },
+  },
   extraReducers: builder => {
     builder.addCase(getProfile.fulfilled, (state, action) => {
       state.currentProfile = action.payload;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

When a user node is clicked in a graph preview profile sidebar appears on the left.
The user can 'expand network', 'add friend', 'see profile' with the buttons provided by the sidebar

## Description
<!--- Describe your changes in detail -->
- implement get friend request between two users in frontend (axios get with queries)
- Add event dispatcher class object for emitting user node click (Canvas now extends event dispatcher class)
- Change useCanvas hook to allow user node click 
- Allow friend side bar and graph to share state by creating a new redux slice named 'canvas'
- Create profile preview sidebar with translate animations
- Add actions for expanding network on one chon and then returning to original graph

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/57612141/204302259-15ca10db-eaa7-451c-9257-d23ae72b55a0.mov



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
